### PR TITLE
Add Mobile-friendly layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "moment": "^2.16.0",
     "moment-timezone": "^0.5.9",
     "next": "^1.1.1",
-    "react-ga": "^2.1.2"
+    "react-ga": "^2.1.2",
+    "react-media": "^1.4.0"
   },
   "scripts": {
     "dev": "next",

--- a/pages/index.js
+++ b/pages/index.js
@@ -108,6 +108,32 @@ class TimezoneSelector extends React.Component {
   
 }
 
+class Match extends React.Component {
+  render () {
+    const { d, match } = this.props
+    return (
+      <hr className={matchDividerStyle}/>
+      <Team d={d} team={match.team} match={match} side='left'/>
+      <div className={divider}> {this.state.timezone ?
+        <div>
+          <div className={dateStyle}>{moment(new Date(match.time + ' UTC')).format('ll')}</div>
+          <div>{this.state.timezone == 'GMT'
+            ? moment(new Date(match.time + ' UTC')).format('HH:mm')
+            : moment(new Date(match.time + ' UTC')).format('LT')}</div>
+        </div>
+        : '...'}</div>
+      <Team d={d} team={match.team_2} match={match} side='right'/>
+      <div className={eventStyle}>
+        {match.event} - {match.round} - {match.format}
+      </div>
+      <div className={streamStyle}>
+        {match.streams.split(',').map(stream => _.get(d, ['streamers', stream])).filter(stream => stream !== undefined).map(
+          (stream) => (<Stream stream={stream} />))}
+      </div>
+    )
+  }
+}
+
 export default class extends React.Component {
   constructor(props) {
     super(props);
@@ -215,24 +241,7 @@ export default class extends React.Component {
         </div>
         {matches.length ? matches.map(match => (
           <div className={matchStyle} onClick={() => test(d)}>
-              <hr className={matchDividerStyle}/>
-              <Team d={d} team={match.team} match={match} side='left'/>
-              <div className={divider}> {this.state.timezone ? 
-                <div>
-                  <div className={dateStyle}>{moment(new Date(match.time + ' UTC')).format('ll')}</div>
-                  <div>{this.state.timezone == 'GMT'
-                    ? moment(new Date(match.time + ' UTC')).format('HH:mm')
-                    : moment(new Date(match.time + ' UTC')).format('LT')}</div>
-                </div>
-                : '...'}</div>
-              <Team d={d} team={match.team_2} match={match} side='right'/>
-              <div className={eventStyle}>
-                {match.event} - {match.round} - {match.format}
-              </div>
-              <div className={streamStyle}>
-                {match.streams.split(',').map(stream => _.get(d, ['streamers', stream])).filter(stream => stream !== undefined).map(
-                  (stream) => (<Stream stream={stream} />))}
-              </div>
+            <Match d={d} match={match} />
           </div>
         ))
         : <div className={merge([matchStyle, css({textAlign: 'center'})])}> 

--- a/pages/index.js
+++ b/pages/index.js
@@ -184,6 +184,7 @@ export default class extends React.Component {
     <div className={general}>
         <Head>
           <title>Professional Age of Empires 2 calendar</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="icon" href="static/favicon.ico" />
         </Head>
         <div className={topNoteStyle}>
@@ -280,17 +281,32 @@ const getRows = (worksheetId, keyName) => {
 }
 
 
+// Media query for styles for mobile devices.
+const mobile = '@media (max-width: 768px)'
+
 // Styling
-const general = css({fontFamily: 'Consolas, monaco, monospace', 
-                      width: 80 * 12 + 'px', 
-                      paddingLeft: 10 + 'px', 
-                      paddingRight: 10 + 'px',
-                      margin: 'auto',
-                      color: '#333333'
+const general = css({
+  fontFamily: 'Consolas, monaco, monospace',
+  width: 80 * 12 + 'px',
+  maxWidth: '100%',
+  paddingLeft: 10 + 'px',
+  paddingRight: 10 + 'px',
+  margin: 'auto',
+  color: '#333333',
+  boxSizing: 'border-box'
 })
 
-
-const filterSelect = css({width: 80 * 2 + 'px', marginLeft: 10 + 'px'})
+const filterSelect = css({
+  width: 80 * 2 + 'px',
+  marginLeft: 10 + 'px',
+  [mobile]: {
+    display: 'block',
+    marginLeft: 0,
+    width: '100%',
+    height: 32 + 'px',
+    marginBottom: 10 + 'px'
+  }
+})
 const filterSwitchOptionActive = css({color: '#333333',  textDecoration: 'none'})
 const filterSwitchOption = css({color: '#C8C8C8', cursor: 'pointer'})
 const filterSwitch = css({textAlign: 'center', display:'inline-block', margin: '0em 1em 0em 1em'})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,6 +1694,12 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  dependencies:
+    string-convert "^0.2.0"
+
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -2242,6 +2248,12 @@ react-hot-loader@3.0.0-beta.6:
     redbox-react "^1.2.5"
     source-map "^0.4.4"
 
+react-media@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-media/-/react-media-1.4.0.tgz#fe2f1f7450d0b08e3cd04b19b21eb71bef64ce98"
+  dependencies:
+    json2mq "^0.2.0"
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -2555,6 +2567,10 @@ stream-browserify@^1.0.0:
 stream-cache@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stream-cache/-/stream-cache-0.0.2.tgz#1ac5ad6832428ca55667dbdee395dad4e6db118f"
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
:wave: This patch adds a few styles to make aoe2calendar.com work a bit better on mobile screens. The main difference is that it vertically stacks the filter select boxes, and displays match data more or less vertically, when viewed on a mobile device.

| Before | After |
|---|---|
| ![Screenshot](http://i.imgur.com/tvRdBCh.png) | ![Screenshot](http://i.imgur.com/clHFMv7.png) |
| Great for desktop, too small for mobile :( | Great for mobile as well \o/ |

It only changes styles on screens narrower than 768px using [react-media](https://github.com/reacttraining/react-media) (and plain CSS media queries). The layout on desktops is unchanged.

---

I think the repository is not 100% up to date, but I'd be happy to rebase when it is :)