### PR TITLE
Detect mobile browsers for server-side renders, closes #2

### DIFF
--- a/components/MatchList.js
+++ b/components/MatchList.js
@@ -6,11 +6,21 @@ import MatchDesktop from './MatchDesktop'
 
 
 export default class MatchList extends React.Component {
+  static contextTypes = {
+    // Whether we're targeting a mobile device during a server-side render.
+    isMobileAgent: React.PropTypes.bool
+  }
+
   render () {
+    const { isMobileAgent } = this.context
     const { d, timezone, matches } = this.props
     return (
       <Media query={mobileBreakpoint}>
-        {isMobile => {
+        {isMobileViewport => {
+          // isMobileAgent is `null` on client renders. We should only use it
+          // for server renders.
+          const isMobile = isMobileAgent !== null ? isMobileAgent : isMobileViewport
+
           const MatchComponent = isMobile ? MatchMobile : MatchDesktop
           return (
             <div>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "browser-request": "^0.3.3",
     "google-spreadsheets": "^0.5.1",
+    "is-mobile": "^0.2.2",
     "jstz": "^1.0.7",
     "lodash": "^4.17.2",
     "moment": "^2.16.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,7 @@ import GSpread from 'google-spreadsheets'
 import moment from 'moment-timezone'
 import Head from 'next/head'
 import ReactGA from 'react-ga'
+import isMobile from 'is-mobile'
 import {general, miniFlag, topNoteStyle, link, matchFilters, footerStyle, matchStyle} from '../styles/common'
 import MatchList from '../components/MatchList'
 import FilterSelect from '../components/FilterSelect'
@@ -47,10 +48,21 @@ export default class extends React.Component {
     // To find new ID, use window.sheet
     return {
       server: req ? true : false,
+      isMobileAgent: req ? isMobile(req) : null,
       players: await getRows('oe5g22b', 'name'),
       matches: await getRows('od6'),
       flags: await getRows('ojz6xko', 'name'),
       streamers: await getRows('o5jbq27', 'name')
+    }
+  }
+
+  static childContextTypes = {
+    isMobileAgent: React.PropTypes.bool
+  }
+
+  getChildContext () {
+    return {
+      isMobileAgent: this.props.isMobileAgent
     }
   }
 


### PR DESCRIPTION
This uses the browser user-agent to check for mobile browsers. If
rendering on the server side, the result of the user-agent check
is used; otherwise, the CSS media query with the mobile breakpoint
is used.

The mobile user-agent match is passed down using React `context`.