### PR TITLE
Speed up initial load time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "moment": "^2.16.0",
     "moment-timezone": "^0.5.9",
     "next": "^1.1.1",
+    "promise-props": "^1.0.0",
     "react-ga": "^2.1.2",
     "react-media": "^1.4.0"
   },

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import moment from 'moment-timezone'
 import Head from 'next/head'
 import ReactGA from 'react-ga'
 import isMobile from 'is-mobile'
+import props from 'promise-props'
 import {general, miniFlag, topNoteStyle, link, matchFilters, footerStyle, matchStyle} from '../styles/common'
 import MatchList from '../components/MatchList'
 import FilterSelect from '../components/FilterSelect'
@@ -54,17 +55,17 @@ export default class extends React.Component {
     ReactGA.pageview(window.location.pathname);
   }
   
-  static async getInitialProps ({ req }) {
+  static getInitialProps ({ req }) {
     // To find new ID, use window.sheet
-    return {
+    return props({
       server: req ? true : false,
       isMobileAgent: req ? isMobile(req) : null,
-      players: await getRows('oe5g22b', 'name'),
-      matches: await getRows('od6'),
-      flags: await getRows('ojz6xko', 'name'),
-      events: await getRows('o1vzpub', 'name'),
-      streamers: await getRows('o5jbq27', 'name')
-    }
+      players: getRows('oe5g22b', 'name'),
+      matches: getRows('od6'),
+      flags: getRows('ojz6xko', 'name'),
+      events: getRows('o1vzpub', 'name'),
+      streamers: getRows('o5jbq27', 'name')
+    })
   }
 
   static childContextTypes = {


### PR DESCRIPTION
`await` waits for one Promise to resolve before firing the next
request. That's unnecessary, because all the data requested in
getInitialProps is independent. This patch runs all the initial
getRows() calls in parallel, using the https://npm.im/promise-props
module.

In my crude tests, this cuts the initial load time from about 4
seconds down to about 2 seconds.